### PR TITLE
rename cntlr -> ctrl

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,7 +1,7 @@
 testonly: False
 with-expecter: True
 packages:
-  github.com/metal-toolbox/cntlr:
+  github.com/metal-toolbox/ctrl:
     config:
       fileName: "mock_{{.InterfaceName | firstLower}}.go"
       inpackage: True

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-This Controller `cntlr` library is imported by Controllers interfacing with the
+This Controller `ctrl` library is imported by Controllers interfacing with the
 [Condition Orchestrator](https://github.com/metal-toolbox/conditionorc).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/metal-toolbox/cntlr
+module github.com/metal-toolbox/ctrl
 
 go 1.22
 


### PR DESCRIPTION
The current name is too typo friendly